### PR TITLE
Upgrade NodeJS version

### DIFF
--- a/.bumpversion.cfg
+++ b/.bumpversion.cfg
@@ -1,5 +1,5 @@
 [bumpversion]
-current_version = 3.1.3
+current_version = 3.2.0
 commit = True
 message = Bumps version to {new_version}
 tag = False

--- a/main.tf
+++ b/main.tf
@@ -12,7 +12,7 @@ module "lambda" {
   function_name = var.name
   description   = "Post messages from AWS to Slack"
   handler       = "aws-to-slack/src/index.handler"
-  runtime       = "nodejs10.x"
+  runtime       = "nodejs14.x"
   timeout       = 10
 
   source_path = "${path.module}/vendor"

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "terraform-aws-slack-notifier",
-  "version": "3.1.3",
+  "version": "3.2.0",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "terraform-aws-slack-notifier",
-  "version": "3.1.3",
+  "version": "3.2.0",
   "description": "Forward AWS Notification Messages to Slack",
   "main": "node_modules/aws-to-slack/src/index.js",
   "author": "Plus3 IT Systems",


### PR DESCRIPTION
This PR upgrades the Node version since AWS [announced](https://aws.amazon.com/blogs/developer/announcing-the-end-of-support-for-node-js-runtimes-10-x-in-the-aws-sdk-for-javascript-v2/) the end of support for Node.js 10.x 

I don't have much experience with Node.js so I'm not sure if the code has to change as well, but I tested this change and the function still works.